### PR TITLE
Update path.php deprecated code

### DIFF
--- a/libraries/path.php
+++ b/libraries/path.php
@@ -114,11 +114,11 @@ class wpl_path
 		for ($i = 0; $i < 3; $i++)
 		{
 			// read
-			$parsed_mode .= ($mode{$i} & 04) ? "r" : "-";
+			$parsed_mode .= ($mode[$i] & 04) ? "r" : "-";
 			// write
-			$parsed_mode .= ($mode{$i} & 02) ? "w" : "-";
+			$parsed_mode .= ($mode[$i] & 02) ? "w" : "-";
 			// execute
-			$parsed_mode .= ($mode{$i} & 01) ? "x" : "-";
+			$parsed_mode .= ($mode[$i] & 01) ? "x" : "-";
 		}
 
 		return $parsed_mode;


### PR DESCRIPTION
A message shows on PHP 7.4, curly braces are deprecated.